### PR TITLE
limit number of parks displayed

### DIFF
--- a/src/admin/src/components/page/advisoryDashboard/AdvisoryDashboard.js
+++ b/src/admin/src/components/page/advisoryDashboard/AdvisoryDashboard.js
@@ -245,7 +245,7 @@ export default function AdvisoryDashboard({ page: { setError } }) {
         if (regionsCount > 0) {
           let regions = rowData.regions
             .slice(0, displayCount)
-            .map((p) => `${p.regionName} (${p.count} parks)`)
+            .map((p) => `${p.regionName} Region (${p.count} parks)`)
             .join(", ");
           if (regionsCount > displayCount) {
             regions = `${regions}... +${regionsCount - displayCount} more`;
@@ -259,7 +259,8 @@ export default function AdvisoryDashboard({ page: { setError } }) {
             .map((p) => p.protectedAreaName)
             .join(", ");
           if (parksCount > displayCount) {
-            parks = `${parks}... (${parksCount} parks)`;
+            // parks = `${parks}... (${parksCount} parks)`;
+            parks = `${parks}... +${parksCount - displayCount} more`;
           }
           return parks;
         }

--- a/src/admin/src/components/page/advisoryDashboard/AdvisoryDashboard.js
+++ b/src/admin/src/components/page/advisoryDashboard/AdvisoryDashboard.js
@@ -259,7 +259,7 @@ export default function AdvisoryDashboard({ page: { setError } }) {
             .map((p) => p.protectedAreaName)
             .join(", ");
           if (parksCount > displayCount) {
-            parks = `${parks} ... +${parksCount - displayCount} more`;
+            parks = `${parks}... (${parksCount} parks)`;
           }
           return parks;
         }


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

- BC-215 : On the Public Advisory Dashboard, display the first three parks and a count of associated parks
- BC-216 : On the Public Advisory Dashboard, display the associated regions

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation
- [ ] Version change

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

## Does the change impact or break the Docker build?

- [ ] Yes
- [x] No

If Yes: Has Docker been updated accordingly?

- [ ] Yes
- [ ] No

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] New and existing unit tests pass locally with my changes
